### PR TITLE
avoid-use-of-REDIS_URL-as-local-var

### DIFF
--- a/bin/gen-twemproxy-conf.sh
+++ b/bin/gen-twemproxy-conf.sh
@@ -3,10 +3,10 @@
 REDIS_URLS=${TWEMPROXY_URLS:-REDISCLOUD_URL}
 n=1
 
-for REDIS_URL in $REDIS_URLS
+for _REDIS_URL in $REDIS_URLS
 do
-  echo "Setting ${REDIS_URL}_TWEMPROXY config var"
-  eval REDIS_URL_VALUE=\$$REDIS_URL
+  echo "Setting ${_REDIS_URL}_TWEMPROXY config var"
+  eval REDIS_URL_VALUE=\$$_REDIS_URL
 
   # redis://rediscloud:UV0d4ikbK7UIegq5@pub-redis-19886.us-east-1-1.2.ec2.garantiadata.com:19886
   DB=$(echo ${REDIS_URL_VALUE} | perl -lne 'print "$1 $2 $3 $4 $5 $6" if /^redis(?:ql)?:\/\/([^:]+):([^@]+)@(.*?):(.*?)(\\?.*)?$/')
@@ -17,12 +17,12 @@ do
   DB_PORT=${DB_URI[3]}
 
   NEW_URL=redis://${DB_USER}:${DB_PASS}@127.0.0.1:620${n}
-  export ${REDIS_URL}_TWEMPROXY=${NEW_URL}
-  export ${REDIS_URL}_UNPROXIED=${REDIS_URL_VALUE}
+  export ${_REDIS_URL}_TWEMPROXY=${NEW_URL}
+  export ${_REDIS_URL}_UNPROXIED=${REDIS_URL_VALUE}
   echo "Pointing to ${DB_HOST}:${DB_PORT}"
 
   cat >> /app/vendor/twemproxy/twemproxy.yml << EOFEOF
-${REDIS_URL}:
+${_REDIS_URL}:
   listen: 127.0.0.1:620${n}
   redis: true
   redis_auth: ${DB_PASS}


### PR DESCRIPTION
PR for ProsperWorks/heroku-buildpack-twemproxy.

WARNING: Because https://github.com/ProsperWorks/ALI/blob/master/.buildpacks contains "https://github.com/Prosperworks/heroku-buildpack-twemproxy", once this PR merges into master then the next time we deploy ALI on each Heroku environment (ali-integration*, ali-staging, api-production) etc., then this change will take effect.

Nonetheless I believe this is relatively safe to do because bin/gen-twemproxy-conf.sh only runs if START_TWEMPROXY=start-twemproxy is defined on the environment in question.  And because of this bug, that var is unset in all environments. 
